### PR TITLE
废弃Mcrypt，改为支持openssl

### DIFF
--- a/crypto/pkcs7Encoder.php
+++ b/crypto/pkcs7Encoder.php
@@ -51,20 +51,15 @@ class Prpcrypt
 			//获得16位随机字符串，填充到明文之前
 			$random = $this->getRandomStr();
 			$text = $random . pack("N", strlen($text)) . $text . $corpid;
-			// 网络字节序
-			$size = mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
-			$module = mcrypt_module_open(MCRYPT_RIJNDAEL_128, '', MCRYPT_MODE_CBC, '');
 			$iv = substr($this->key, 0, 16);
 			//使用自定义的填充方式对明文进行补位填充
 			$pkc_encoder = new PKCS7Encoder;
 			$text = $pkc_encoder->encode($text);
-			mcrypt_generic_init($module, $this->key, $iv);
-			//加密
-			$encrypted = mcrypt_generic($module, $text);
-			mcrypt_generic_deinit($module);
-			mcrypt_module_close($module);
 
-			//print(base64_encode($encrypted));
+			//加密
+			$cipher = 'AES-256-CBC';
+			$encrypted = \openssl_encrypt($text, $cipher, $this->key, OPENSSL_RAW_DATA|OPENSSL_ZERO_PADDING, $iv);
+
 			//使用BASE64对加密后的字符串进行编码
 			return array(ErrorCode::$OK, base64_encode($encrypted));
 		} catch (Exception $e) {
@@ -78,13 +73,9 @@ class Prpcrypt
 
 		try {
 			$ciphertext_dec = base64_decode($encrypted);
-			$module = mcrypt_module_open(MCRYPT_RIJNDAEL_128, '', MCRYPT_MODE_CBC, '');
 			$iv = substr($this->key, 0, 16);
-			mcrypt_generic_init($module, $this->key, $iv);
-
-			$decrypted = mdecrypt_generic($module, $ciphertext_dec);
-			mcrypt_generic_deinit($module);
-			mcrypt_module_close($module);
+			$cipher = 'AES-256-CBC';
+			$decrypted = \openssl_decrypt($ciphertext_dec, $cipher, $this->key, OPENSSL_RAW_DATA|OPENSSL_ZERO_PADDING, $iv);
 		} catch (Exception $e) {
 			return array(ErrorCode::$DecryptAESError, null);
 		}
@@ -125,5 +116,3 @@ class Prpcrypt
 	}
 
 }
-
-?>


### PR DESCRIPTION
因为PHP7.1以后不再支持Mcrypt模块，现改为openssl做AES的加解密，实测可用